### PR TITLE
Expire API cache entries

### DIFF
--- a/src/main/java/xyz/verarr/synchrono/IRLTimeManager.java
+++ b/src/main/java/xyz/verarr/synchrono/IRLTimeManager.java
@@ -9,7 +9,6 @@ import xyz.verarr.synchrono.config.SynchronoConfig;
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.function.Function;
 
 import xyz.verarr.synchrono.external_apis.SunriseSunsetAPI;
 import xyz.verarr.synchrono.external_apis.SunriseSunsetAPI.SunriseSunsetData;
@@ -80,10 +79,9 @@ public class IRLTimeManager extends PersistentState {
         tomorrow = dateTime.plusDays(1).toLocalDate();
 
         SunriseSunsetData yesterday_data, today_data, tomorrow_data;
-        Function<LocalDate, SunriseSunsetData> queryAPIFunction = (day) -> SunriseSunsetAPI.query(day, SynchronoConfig.latitude, SynchronoConfig.longitude, SynchronoConfig.timezone());
-        yesterday_data = sunriseSunsetDataCache.computeIfAbsent(yesterday, queryAPIFunction);
-        today_data = sunriseSunsetDataCache.computeIfAbsent(today, queryAPIFunction);
-        tomorrow_data = sunriseSunsetDataCache.computeIfAbsent(tomorrow, queryAPIFunction);
+        yesterday_data = cachedQuery(yesterday);
+        today_data = cachedQuery(today);
+        tomorrow_data = cachedQuery(tomorrow);
 
         if (dateTime.isBefore(dateTime.toLocalDate().atTime(today_data.sunrise))) {
             // before sunrise - use yesterday_data (and today_data)
@@ -141,10 +139,9 @@ public class IRLTimeManager extends PersistentState {
         tomorrow = dateTime.plusDays(1).toLocalDate();
 
         SunriseSunsetData yesterday_data, today_data, tomorrow_data;
-        Function<LocalDate, SunriseSunsetData> queryAPIFunction = (day) -> SunriseSunsetAPI.query(day, SynchronoConfig.latitude, SynchronoConfig.longitude, SynchronoConfig.timezone());
-        yesterday_data = sunriseSunsetDataCache.computeIfAbsent(yesterday, queryAPIFunction);
-        today_data = sunriseSunsetDataCache.computeIfAbsent(today, queryAPIFunction);
-        tomorrow_data = sunriseSunsetDataCache.computeIfAbsent(tomorrow, queryAPIFunction);
+        yesterday_data = cachedQuery(yesterday);
+        today_data = cachedQuery(today);
+        tomorrow_data = cachedQuery(tomorrow);
 
         if (dateTime.isBefore(today.atTime(today_data.sunrise))) {
             // update next daytime aka today
@@ -165,10 +162,9 @@ public class IRLTimeManager extends PersistentState {
         tomorrow = dateTime.plusDays(1).toLocalDate();
 
         SunriseSunsetData yesterday_data, today_data, tomorrow_data;
-        Function<LocalDate, SunriseSunsetData> queryAPIFunction = (day) -> SunriseSunsetAPI.query(day, SynchronoConfig.latitude, SynchronoConfig.longitude, SynchronoConfig.timezone());
-        yesterday_data = sunriseSunsetDataCache.computeIfAbsent(yesterday, queryAPIFunction);
-        today_data = sunriseSunsetDataCache.computeIfAbsent(today, queryAPIFunction);
-        tomorrow_data = sunriseSunsetDataCache.computeIfAbsent(tomorrow, queryAPIFunction);
+        yesterday_data = cachedQuery(yesterday);
+        today_data = cachedQuery(today);
+        tomorrow_data = cachedQuery(tomorrow);
 
         if (dateTime.isBefore(today.atTime(today_data.sunrise))) {
             // update current nighttime aka yesterday and today

--- a/src/main/java/xyz/verarr/synchrono/IRLTimeManager.java
+++ b/src/main/java/xyz/verarr/synchrono/IRLTimeManager.java
@@ -48,16 +48,6 @@ public class IRLTimeManager extends PersistentState {
         return world.getPersistentStateManager().getOrCreate(IRLTimeManager.type, Synchrono.MOD_ID);
     }
 
-    public void cacheNextDay() {
-        LocalDate tomorrow = LocalDate.now(SynchronoConfig.timezone()).plusDays(1);
-        if (sunriseSunsetDataCache.containsKey(tomorrow)) return;
-
-        SunriseSunsetData tomorrow_data;
-        tomorrow_data = SunriseSunsetAPI.query(tomorrow, SynchronoConfig.latitude, SynchronoConfig.longitude, SynchronoConfig.timezone());
-
-        sunriseSunsetDataCache.put(tomorrow, tomorrow_data);
-    }
-
     private void cacheMaintenance() {
         sunriseSunsetDataCache.keySet().removeIf(key -> key.isBefore(LocalDate.now().minusDays(1)));
     }

--- a/src/main/java/xyz/verarr/synchrono/IRLTimeManager.java
+++ b/src/main/java/xyz/verarr/synchrono/IRLTimeManager.java
@@ -59,6 +59,16 @@ public class IRLTimeManager extends PersistentState {
         sunriseSunsetDataCache.put(tomorrow, tomorrow_data);
     }
 
+    private void cacheMaintenance() {
+        sunriseSunsetDataCache.keySet().removeIf(key -> key.isBefore(LocalDate.now().minusDays(1)));
+    }
+
+    private SunriseSunsetData cachedQuery(LocalDate localDate) {
+        cacheMaintenance();
+        return sunriseSunsetDataCache.computeIfAbsent(localDate,
+                (day) -> SunriseSunsetAPI.query(day, SynchronoConfig.latitude, SynchronoConfig.longitude, SynchronoConfig.timezone()));
+    }
+
     public long tickAt(LocalDateTime dateTime) {
         long ticks;
 


### PR DESCRIPTION
Maintenance runs on every query, but it shouldn't be that long because there should be at most about 4 (or 5.. maybe..?) entries.